### PR TITLE
Remove default realm, cleanup urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ description: Tutorials and Reference for the ARENA project.
 url: https://arena.conix.io
 aux_links:
   "The ARENA":
-    - "https://arena.andrew.cmu.edu/"
+    - "https://arenaxr.org/"
   "CONIX Research Center":
     - "https://conix.io/arena"
   "Our GitHub":

--- a/content/3d-content/animated-models.md
+++ b/content/3d-content/animated-models.md
@@ -16,7 +16,7 @@ Animate rotation of the already drawn cube.
 Raw Message
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/cube_1 -m '{"object_id" : "cube_1", "action": "update", "type": "object", "data": { "animation": { "property": "rotation", "to": "0 360 0", "loop": true, "dur": 10000}} }'
+mosquitto_pub -h arenaxr.org -t realm/s/example/cube_1 -m '{"object_id" : "cube_1", "action": "update", "type": "object", "data": { "animation": { "property": "rotation", "to": "0 360 0", "loop": true, "dur": 10000}} }'
 ```
 
 Python

--- a/content/3d-content/dimension.md
+++ b/content/3d-content/dimension.md
@@ -28,6 +28,6 @@ Move the model or resize it however you desire. Then, in the scene list on the r
 
 ![](../../assets/img/dimension/d4.jpg)
 
-When selecting the format, select GLB, not GLTF. For some reason, the exported GLTF files from dimension don't seem to work on GLTFViewer/ARENA. You can change the name of the file and export location in "Save To". Click Export, and you're done! Now you can upload to [the filestore](https://arena.andrew.cmu.edu/storemng/) and add to the ARENA.
+When selecting the format, select GLB, not GLTF. For some reason, the exported GLTF files from dimension don't seem to work on GLTFViewer/ARENA. You can change the name of the file and export location in "Save To". Click Export, and you're done! Now you can upload to [the filestore](https://arenaxr.org/storemng/) and add to the ARENA.
 
 ![](../../assets/img/dimension/d5.jpg)

--- a/content/arts/python.md
+++ b/content/arts/python.md
@@ -15,19 +15,19 @@ This example needs to be updated for a new user.
 Quick Reference
 ---------------
 
-* Scene [https://arena.andrew.cmu.edu/public/pytest](https://arena.andrew.cmu.edu/public/pytest) loads a Python program stored at the [file store](https://arena.andrew.cmu.edu/storemng), under folder boxes for user **wiselab**.
-* Go to the [file store](https://arena.andrew.cmu.edu/storemng) and edit **boxes/boxes.py** to see the program code.
-* Edit this scene in the [builder](https://arena.andrew.cmu.edu/build/), to see the program object stored.
-* See the [ARTS gui](https://arena.andrew.cmu.edu/arts/) to see the runtimes and modules running.
+* Scene [https://arenaxr.org/public/pytest](https://arenaxr.org/public/pytest) loads a Python program stored at the [file store](https://arenaxr.org/storemng), under folder boxes for user **wiselab**.
+* Go to the [file store](https://arenaxr.org/storemng) and edit **boxes/boxes.py** to see the program code.
+* Edit this scene in the [builder](https://arenaxr.org/build/), to see the program object stored.
+* See the [ARTS gui](https://arenaxr.org/arts/) to see the runtimes and modules running.
 
 Step by Step Example
 --------------------
 
-How to launch a program (e.g. **boxes/boxes.py**) in a [file store](https://arena.andrew.cmu.edu/storemng).
+How to launch a program (e.g. **boxes/boxes.py**) in a [file store](https://arenaxr.org/storemng).
 
-1\. Edit Scene: [https://arena.andrew.cmu.edu/build/](https://arena.andrew.cmu.edu/build/)
+1\. Edit Scene: [https://arenaxr.org/build/](https://arenaxr.org/build/)
 
-2\. Make sure the ARENA and MQTT host are **https://arena.andrew.cmu.edu/** and **arena.andrew.cmu.edu:8083**:
+2\. Make sure the ARENA and MQTT host are **https://arenaxr.org/** and **arenaxr.org:8083**:
 
 ![](../../assets/img/arts-program/image4.png){:width="300px"}
 
@@ -60,7 +60,7 @@ By convention, we pass programs environment variables that indicate the scene, r
 
 ![](../../assets/img/arts-program/image3.png){:width="80%"}
 
-7\. Goto to the folder of the program in the [file store](https://arena.andrew.cmu.edu/storemng) and add your files there. These can be wasm programs or Python programs that use the **arena.py** library. See an example in **[wiselab/boxes](https://arena.andrew.cmu.edu/storemng/share/1KoiGaWq)**.
+7\. Goto to the folder of the program in the [file store](https://arenaxr.org/storemng) and add your files there. These can be wasm programs or Python programs that use the **arena.py** library. See an example in **[wiselab/boxes](https://arenaxr.org/storemng/share/1KoiGaWq)**.
 
 {% include alert type="warning" title="Authentication" content="
 You also need to include a `requirements.txt` with your `.py` files providing the authentication version of the ARENA Python library that has at least the line:
@@ -69,6 +69,6 @@ arena-py
 ```
 "%}
 
-8\. Open the Scene using ![](../../assets/img/arts-program/image9.png){:width="200px"}at the top of the build page (the link should be something like https://arena.andrew.cmu.edu/[your username]/\[scene-name\])
+8\. Open the Scene using ![](../../assets/img/arts-program/image9.png){:width="200px"}at the top of the build page (the link should be something like https://arenaxr.org/[your username]/\[scene-name\])
 
-9\. See ARTS GUI: [https://arena.andrew.cmu.edu/arts/](https://arena.andrew.cmu.edu/arts/)
+9\. See ARTS GUI: [https://arenaxr.org/arts/](https://arenaxr.org/arts/)

--- a/content/developer/aframe.md
+++ b/content/developer/aframe.md
@@ -30,7 +30,7 @@ for (let i = 0; i < len; i++) {
 Example:
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/duck_1 -m '{ "object_id" : "duck_1", "action": "update", "type": "object", "data": { "animation": { "property": "rotation", "to": "0 360 0", "loop": true, "dur": 10000 } } }'
+mosquitto_pub -h arenaxr.org -t realm/s/example/duck_1 -m '{ "object_id" : "duck_1", "action": "update", "type": "object", "data": { "animation": { "property": "rotation", "to": "0 360 0", "loop": true, "dur": 10000 } } }'
 ```
 
 {% include alert type="warning" title="Coming Soon" content="Stay tuned for more details..." %}

--- a/content/localization/optical-markers.md
+++ b/content/localization/optical-markers.md
@@ -38,7 +38,7 @@ The AprilTag detection requires that the browser supports computer vision while 
 
 After installing WebXRViewer, go to 'Settings -> XRViewer' and change:
 
-**WebXR Polyfill URL**: ```https://arenaxr.org/vendor/webxr-webxrviewer-ios.js```
+**WebXR Polyfill URL**:  ```https://arenaxr.org/webxrios.js``` or ```https://arenaxr.org/vendor/webxr-webxrviewer-ios.js```
 
 **Always Allow World Sensing**:```Yes```
 

--- a/content/messaging/definitions.md
+++ b/content/messaging/definitions.md
@@ -318,7 +318,7 @@ Follows [aframe-spe-particles-component](https://github.com/harlyq/aframe-spe-pa
 -------------------------
 
 ## "Program Data" object
-Follows [ARENA Program Schema](https://arena.andrew.cmu.edu/build/arena-program.json)
+Follows [ARENA Program Schema](https://arenaxr.org/build/arena-program.json)
 
 ### properties
 
@@ -334,7 +334,7 @@ Follows [ARENA Program Schema](https://arena.andrew.cmu.edu/build/arena-program.
 | channels | *A* | [`Channel` object](#channel-object) array | Channels describe files representing access to IO from pubsub and client sockets (possibly more in the future; currently only supported for WASM programs).
 
 ## "channel" object
-Follows [ARENA Program Schema](https://arena.andrew.cmu.edu/build/arena-program.json)
+Follows [ARENA Program Schema](https://arenaxr.org/build/arena-program.json)
 
 ### properties
 
@@ -346,7 +346,7 @@ Follows [ARENA Program Schema](https://arena.andrew.cmu.edu/build/arena-program.
 | params | *A* | [`Params` object](#params-object) | Type (i.e. pubsub/client)-specific parameters.
 
 ## "params" object
-Follows [ARENA Program Schema](https://arena.andrew.cmu.edu/build/arena-program.json)
+Follows [ARENA Program Schema](https://arenaxr.org/build/arena-program.json)
 
 ### properties
 
@@ -359,7 +359,7 @@ Follows [ARENA Program Schema](https://arena.andrew.cmu.edu/build/arena-program.
 -------------------------
 
 ## "Scene Options Data" object
-Follows [ARENA Scene Options Schema](https://arena.andrew.cmu.edu/build/arena-scene-options.json)
+Follows [ARENA Scene Options Schema](https://arenaxr.org/build/arena-scene-options.json)
 
 ### properties
 
@@ -369,7 +369,7 @@ Follows [ARENA Scene Options Schema](https://arena.andrew.cmu.edu/build/arena-sc
 | scene-options | *A* | [`scene-options` object](#scene-options-object) | Scene Options.
 
 ## "env-presets" object
-Follows [ARENA Scene Options Schema](https://arena.andrew.cmu.edu/build/arena-scene-options.json) from the [aframe-environment-component](https://github.com/supermedium/aframe-environment-component).
+Follows [ARENA Scene Options Schema](https://arenaxr.org/build/arena-scene-options.json) from the [aframe-environment-component](https://github.com/supermedium/aframe-environment-component).
 
 ### properties
 
@@ -405,7 +405,7 @@ Follows [ARENA Scene Options Schema](https://arena.andrew.cmu.edu/build/arena-sc
 | gridColor | *A* | `string` | Color of the grid. (*default: "#ccc"*)
 
 ## "scene-options" object
-Follows [ARENA Scene Options Schema](https://arena.andrew.cmu.edu/build/arena-scene-options.json)
+Follows [ARENA Scene Options Schema](https://arenaxr.org/build/arena-scene-options.json)
 
 ### properties
 
@@ -420,7 +420,7 @@ Follows [ARENA Scene Options Schema](https://arena.andrew.cmu.edu/build/arena-sc
 -------------------------
 
 ## "Landmarks Data" object
-Follows [ARENA Landmarks Schema](https://arena.andrew.cmu.edu/build/arena-landmarks.json)
+Follows [ARENA Landmarks Schema](https://arenaxr.org/build/arena-landmarks.json)
 
 ### properties
 
@@ -429,7 +429,7 @@ Follows [ARENA Landmarks Schema](https://arena.andrew.cmu.edu/build/arena-landma
 | landmarks | *A* | [`Landmark` object](#landmark-object) array | List of landmarks of the scene. (**required**)
 
 ## "landmark" object
-Follows [ARENA Landmarks Schema](https://arena.andrew.cmu.edu/build/arena-landmarks.json)
+Follows [ARENA Landmarks Schema](https://arenaxr.org/build/arena-landmarks.json)
 
 ### properties
 

--- a/content/messaging/examples.md
+++ b/content/messaging/examples.md
@@ -18,7 +18,7 @@ The structure of our MQTT messaging format is standardized into JSON. To run som
 Instantiate a cube and set all of it's basic parameters.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "create", "type": "object", "data": {"object_type": "cube", "position": {"x": 1, "y": 1, "z": -1}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}, "color": "#FF0000"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "create", "type": "object", "data": {"object_type": "cube", "position": {"x": 1, "y": 1, "z": -1}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}, "color": "#FF0000"}}'
 ```
 
 ## Color
@@ -26,7 +26,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"obj
 Change only the color of the already-drawn cube.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"material": {"color": "#00FF00"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"material": {"color": "#00FF00"}}}'
 ```
 
 ## Transparency
@@ -34,7 +34,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"obj
 Say the cube has already been drawn. In a second command, this sets 50% transparency.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"material": {"transparent": true, "opacity": 0.5}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"material": {"transparent": true, "opacity": 0.5}}}'
 ```
 
 ## Move
@@ -42,7 +42,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"obj
 Move the position of the already drawn cube.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"position": {"x": 2, "y": 2, "z": -1}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"position": {"x": 2, "y": 2, "z": -1}}}'
 ```
 
 ## Rotate
@@ -50,7 +50,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"obj
 Rotate the already drawn cube; these are in quaternions, not A-Frame degrees.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"rotation": {"x": 60, "y": 2, "z": 3}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"rotation": {"x": 60, "y": 2, "z": 3}}}'
 ```
 
 The quaternion (native) representation of rotation is a bit more tricky. The 4 parameters are X, Y, Z, W. Here are some simple examples:
@@ -64,7 +64,7 @@ The quaternion (native) representation of rotation is a bit more tricky. The 4 p
 Animate rotation of the already drawn cube.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": { "animation": { "property": "rotation", "to": "0 360 0", "loop": true, "dur": 10000}} }'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": { "animation": { "property": "rotation", "to": "0 360 0", "loop": true, "dur": 10000}} }'
 ```
 
 Other animations are available that resemble the `"data": {"animation": { "property": ... }}` blob above: see [A-Frame Animation](https://aframe.io/docs/1.0.0/components/animation.html) documentation for more examples.
@@ -74,7 +74,7 @@ Other animations are available that resemble the `"data": {"animation": { "prope
 Remove the cube.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "delete"}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "delete"}'
 ```
 
 ## Images
@@ -82,14 +82,14 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"obj
 Create an image on the floor.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/image_floor -m '{"object_id": "image_floor", "action": "create", "data": {"object_type": "image", "position": {"x": 0, "y": 0, "z": 0.4}, "rotation": {"x": -0.7, "y": 0, "z": 0, "w": 0.7}, "url": "images/floor.png", "scale": {"x": 12, "y": 12, "z": 2}, "material": {"repeat": {"x": 4, "y": 4}}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/image_floor -m '{"object_id": "image_floor", "action": "create", "data": {"object_type": "image", "position": {"x": 0, "y": 0, "z": 0.4}, "rotation": {"x": -0.7, "y": 0, "z": 0, "w": 0.7}, "url": "images/floor.png", "scale": {"x": 12, "y": 12, "z": 2}, "material": {"repeat": {"x": 4, "y": 4}}}}'
 ```
 
-URLs work in the URL parameter slot. Instead of `images/2.png` it would be e.g. `url(http://arena.andrew.cmu.edu/images/foo.jpg)`.
+URLs work in the URL parameter slot. Instead of `images/2.png` it would be e.g. `url(http://arenaxr.org/images/foo.jpg)`.
 To update the image of a named image already in the scene, use this syntax.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/image_2 -m '{"object_id": "image_2", "action": "update", "type": "object", "data": {"material": {"src": "https://arena.andrew.cmu.edu/abstract/downtown.png"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/image_2 -m '{"object_id": "image_2", "action": "update", "type": "object", "data": {"material": {"src": "https://arenaxr.org/abstract/downtown.png"}}}'
 ```
 
 ## Images on Objects
@@ -97,7 +97,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/image_2 -m '{"ob
 Use the `multisrc` A-Frame Component to specify different bitmaps for sides of a cube or other primitive shape.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/die1 -m '{"object_id": "die1", "action": "create", "type": "object", "data": {"object_type": "cube", "position": {"x": 0, "y": 0.5, "z": -2}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}, "color": "#ffffff", "dynamic-body": {"type": "dynamic"}, "multisrc": {"srcspath": "images/dice/", "srcs": "side1.png, side2.png, side3.png, side4.png, side5.png, side6.png"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/die1 -m '{"object_id": "die1", "action": "create", "type": "object", "data": {"object_type": "cube", "position": {"x": 0, "y": 0.5, "z": -2}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}, "color": "#ffffff", "dynamic-body": {"type": "dynamic"}, "multisrc": {"srcspath": "images/dice/", "srcs": "side1.png, side2.png, side3.png, side4.png, side5.png, side6.png"}}}'
 ```
 
 ## Other Primitives: TorusKnot
@@ -105,9 +105,9 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/die1 -m '{"objec
 Instantiate a wacky torusKnot, then turn it blue. Other primitive types are available in the in [A-Frame docs](https://aframe.io/docs/1.0.0/components/geometry.html#built-in-geometries). Here is a brief list: **box circle cone cylinder dodecahedron icosahedron tetrahedron octahedron plane ring sphere torus torusKnot triangle**.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/torusKnot_1 -m '{"object_id": "torusKnot_1", "action": "create", "data": {"object_type": "torusKnot", "color": "red", "position": {"x": 0, "y": 1, "z": -4}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/torusKnot_1 -m '{"object_id": "torusKnot_1", "action": "create", "data": {"object_type": "torusKnot", "color": "red", "position": {"x": 0, "y": 1, "z": -4}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}}}'
 
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/torusKnot_1 -m '{"object_id": "torusKnot_1", "action": "update", "type": "object", "data": {"material": {"color": "blue"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/torusKnot_1 -m '{"object_id": "torusKnot_1", "action": "update", "type": "object", "data": {"material": {"color": "blue"}}}'
 ```
 
 ## Models
@@ -115,7 +115,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/torusKnot_1 -m '
 Instantiate a glTF v2.0 binary model (file extension .glb) from a URL.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/gltf-model_1 -m '{"object_id": "gltf-model_1", "action": "create", "data": {"object_type": "gltf-model", "url": "https://arena.andrew.cmu.edu/models/Duck.glb", "position": {"x": 0, "y": 1, "z": -4}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/gltf-model_1 -m '{"object_id": "gltf-model_1", "action": "create", "data": {"object_type": "gltf-model", "url": "https://arenaxr.org/models/Duck.glb", "position": {"x": 0, "y": 1, "z": -4}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}}}'
 ```
 
 ## Animating GLTF Models
@@ -123,7 +123,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/gltf-model_1 -m 
 To animate a GLTF model (see [GLTF Files](../3d-content/gltf-files) for how to find animation names), and set the animation-mixer parameter.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/gltf-model_3 -m '{"object_id": "gltf-model_3", "action": "update", "type": "object", "data": {"animation-mixer": {"clip": "*"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/gltf-model_3 -m '{"object_id": "gltf-model_3", "action": "update", "type": "object", "data": {"animation-mixer": {"clip": "*"}}}'
 ```
 
 The asterisk means "play all animations", and works better in some situations, where other times the name of a specific animation in the GLTF file works (or maybe several in sequence).
@@ -133,7 +133,7 @@ The asterisk means "play all animations", and works better in some situations, w
 Move the camera rig (parent object of the camera) with ID camera_1234567890_er1k to a new coordinate (system). Values are x, y, z, (meters) x, y, z, w (quaternions).
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/camera_1234567890_er1k -m '{"object_id": "camera_1234567890_er1k", "action": "update", "type": "rig", "data": {"position": {"x": 1, "y": 1, "z": 1}, "rotation": {"x": 0.1, "y": 0, "z": 0, "w": 1} }}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/camera_1234567890_er1k -m '{"object_id": "camera_1234567890_er1k", "action": "update", "type": "rig", "data": {"position": {"x": 1, "y": 1, "z": 1}, "rotation": {"x": 0.1, "y": 0, "z": 0, "w": 1} }}'
 ```
 
 This assumes we know our camera ID was assigned as `1234567890`. One way to find out your camera ID is, automatically assigned ones get printed on web browsers' Developer Tools Console in a message like `my-camera name camera_1234567890_X`. That might not be easily knowable without snooping MQTT messages, so the `&fixedCamera=er1k` URL parameter lets us choose manually the unique ID. If used in the URL, the `&name=` parameter is ignored, and the derived camera/user ID is based on fixedCamera, so would be in this case `camera_er1k_er1k`
@@ -143,7 +143,7 @@ This assumes we know our camera ID was assigned as `1234567890`. One way to find
 Move the camera with ID `camera_1234567890_er1k` to a new position. Values are x, y, z, (meters) x, y, z, w (quaternions). Action must be `update`.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/camera_1234567890_er1k -m '{"object_id":"camera_1234567890_er1k","action":"update","type":"camera-override","data":{"object_type":"camera","position":{"x":1.692,"y":1.6,"z":4.371},"rotation":{"x":0.003,"y":-0.003,"z":0,"w":1}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/camera_1234567890_er1k -m '{"object_id":"camera_1234567890_er1k","action":"update","type":"camera-override","data":{"object_type":"camera","position":{"x":1.692,"y":1.6,"z":4.371},"rotation":{"x":0.003,"y":-0.003,"z":0,"w":1}}}'
 ```
 
 This assumes we know our camera ID. One way to find out your camera ID is, automatically assigned ones get printed on web browsers' Developer Tools Console.
@@ -154,9 +154,9 @@ Make the camera with ID `camera_1234567890_er1k` look at an object or coordinate
 
 ```json
 
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/camera_1234567890_er1k -m '{"object_id":"camera_1234567890_er1k","action":"update","type":"camera-override","data":{"object_type":"look-at","target":"cone_587431"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/camera_1234567890_er1k -m '{"object_id":"camera_1234567890_er1k","action":"update","type":"camera-override","data":{"object_type":"look-at","target":"cone_587431"}}'
 
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/camera_1234567890_er1k -m '{"object_id":"camera_1234567890_er1k","action":"update","type":"camera-override","data":{"object_type":"look-at","target":{"x": 0.467, "y": 2.066, "z": -1.027}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/camera_1234567890_er1k -m '{"object_id":"camera_1234567890_er1k","action":"update","type":"camera-override","data":{"object_type":"look-at","target":{"x": 0.467, "y": 2.066, "z": -1.027}}}'
 ```
 
 This assumes we know our camera ID. One way to find out your camera ID is, automatically assigned ones get printed on web browsers' Developer Tools Console.
@@ -166,13 +166,13 @@ This assumes we know our camera ID. One way to find out your camera ID is, autom
 Add some red text that says "Hello World".
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/text_3 -m '{"object_id": "text_3", "action": "create", "data": {"color": "red", "text": "Hello world!", "object_type": "text", "position": {"x": 0, "y": 3, "z": -4}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/text_3 -m '{"object_id": "text_3", "action": "create", "data": {"color": "red", "text": "Hello world!", "object_type": "text", "position": {"x": 0, "y": 3, "z": -4}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 1, "y": 1, "z": 1}}}'
 ```
 
 Change text color properties [A-Frame Text](https://aframe.io/docs/0.9.0/components/text.html#properties).
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/text_3 -m '{"object_id": "text_3", "action": "update", "type": "object", "data": {"text": {"color": "green"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/text_3 -m '{"object_id": "text_3", "action": "update", "type": "object", "data": {"text": {"color": "green"}}}'
 ```
 
 ## Lights
@@ -180,13 +180,13 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/text_3 -m '{"obj
 Create a red light in the scene.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/light_3 -m '{"object_id": "light_3", "action": "create", "data": {"object_type": "light", "position": {"x": 1, "y": 1, "z": 1}, "rotation": {"x": 0.25, "y": 0.25, "z": 0, "w": 1}, "color": "#FF0000"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/light_3 -m '{"object_id": "light_3", "action": "create", "data": {"object_type": "light", "position": {"x": 1, "y": 1, "z": 1}, "rotation": {"x": 0.25, "y": 0.25, "z": 0, "w": 1}, "color": "#FF0000"}}'
 ```
 
 Default is ambient light. To change type, or other light [A-Frame Light](https://aframe.io/docs/0.9.0/components/light.html) parameters, example: change to **directional**. Options: **ambient, directional, hemisphere, point, spot**.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/light_3 -m '{"object_id": "light_3", "action": "update", "type": "object", "data": {"light": {"type": "directional"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/light_3 -m '{"object_id": "light_3", "action": "update", "type": "object", "data": {"light": {"type": "directional"}}}'
 ```
 
 ## Sound
@@ -194,7 +194,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/light_3 -m '{"ob
 Play toy piano sound from a URL when you click a cube. Sets click-listener Component, waveform URL, and sound attribute.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/box_asharp -m '{"object_id": "box_asharp", "action": "create", "data": {"object_type": "cube", "position": {"x": 2.5, "y": 0.25, "z": -5}, "scale": {"x": 0.8, "y": 1, "z": 1}, "color": "#000000", "sound": {"src": "url(https://arena.andrew.cmu.edu/audio/toypiano/Asharp1.wav)", "on": "mousedown"}, "click-listener": ""}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/box_asharp -m '{"object_id": "box_asharp", "action": "create", "data": {"object_type": "cube", "position": {"x": 2.5, "y": 0.25, "z": -5}, "scale": {"x": 0.8, "y": 1, "z": 1}, "color": "#000000", "sound": {"src": "url(https://arenaxr.org/audio/toypiano/Asharp1.wav)", "on": "mousedown"}, "click-listener": ""}}'
 ```
 
 ## 360 Video
@@ -202,7 +202,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/box_asharp -m '{
 Draw a sphere, set the texture src to be an equirectangular video, on the 'back' (inside).
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/sphere_vid -m '{"object_id": "sphere_vid", "action": "create", "type": "object", "data": {"object_type": "sphere", "scale": {"x": 200, "y": 200, "z": 200}, "rotation": {"x": 0, "y": 0.7, "z": 0, "w": 0.7}, "color": "#808080", "material": {"src": "images/360falls.mp4", "side": "back"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/sphere_vid -m '{"object_id": "sphere_vid", "action": "create", "type": "object", "data": {"object_type": "sphere", "scale": {"x": 200, "y": 200, "z": 200}, "rotation": {"x": 0, "y": 0.7, "z": 0, "w": 0.7}, "color": "#808080", "material": {"src": "images/360falls.mp4", "side": "back"}}}'
 ```
 
 ## Lines
@@ -210,13 +210,13 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/sphere_vid -m '{
 Draw a purple line from (2, 2, 2) to (3, 3, 3).
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/line_1 -m '{"object_id": "line_1", "action": "create", "data": {"object_type": "line", "start": {"x": 2, "y": 2, "z": 2}, "end": {"x": 3, "y": 3, "z": 3}, "color": "#CE00FF"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/line_1 -m '{"object_id": "line_1", "action": "create", "data": {"object_type": "line", "start": {"x": 2, "y": 2, "z": 2}, "end": {"x": 3, "y": 3, "z": 3}, "color": "#CE00FF"}}'
 ```
 
 Extend the line with a new segment, colored green.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/line_1 -m '{"object_id": "line_1", "action": "update", "type": "object", "data": {"line__2": {"start": {"x": 3, "y": 3, "z": 3}, "end": {"x": 4, "y": 4, "z": 4}, "color": "#00FF00"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/line_1 -m '{"object_id": "line_1", "action": "update", "type": "object", "data": {"line__2": {"start": {"x": 3, "y": 3, "z": 3}, "end": {"x": 4, "y": 4, "z": 4}, "color": "#00FF00"}}}'
 ```
 
 ## Thicklines
@@ -224,13 +224,13 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/line_1 -m '{"obj
 A "thickline" (to improve openpose skeleton rendering visibility) - works like a line, but the `lineWidth` value specifies thickness, and multiple points can be specified at once, e.g. draw a pink line 11 pixels thick from 0, 0, 0 to 1, 0, 0 to 1, 1, 0 to 1, 1, 1. The shorthand syntax for coordinates is a bonus feature of lower level code; extending it for the rest of ARENA commands remains as an enhancement.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/thickline_8 -m '{"object_id": "thickline_8", "action": "create", "type": "object", "data": {"object_type": "thickline", "lineWidth": 11, "color": "#FF88EE", "path": "0 0 0, 1 0 0, 1 1 0, 1 1 1"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/thickline_8 -m '{"object_id": "thickline_8", "action": "create", "type": "object", "data": {"object_type": "thickline", "lineWidth": 11, "color": "#FF88EE", "path": "0 0 0, 1 0 0, 1 1 0, 1 1 1"}}'
 ```
 
 You might be wondering, why can't normal lines just use the scale value to specify thickness? But this one goes to eleven! Really though, normal lines perform faster. To update a "thickline" takes a special syntax because thicklines are really "meshline"s.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/thickline_8 -m '{"object_id": "thickline_8", "action": "update", "type": "object", "data": {"meshline": {"lineWidth": 11, "color": "#FFFFFF", "path": "0 0 0, 0 0 1"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/thickline_8 -m '{"object_id": "thickline_8", "action": "update", "type": "object", "data": {"meshline": {"lineWidth": 11, "color": "#FFFFFF", "path": "0 0 0, 0 0 1"}}}'
 ```
 
 ## Events
@@ -238,7 +238,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/thickline_8 -m '
 Add the "click-listener" event to a scene object; click-listener is a Component defined in `events.js`. This works for adding other, arbitrary Components. A non-empty message gets sent to the Component's `init: ` function.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"click-listener": "enable"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id": "cube_1", "action": "update", "type": "object", "data": {"click-listener": "enable"}}'
 ```
 
 ## Persisted Objects
@@ -246,7 +246,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"obj
 If we want our objects to return to the scene when we next open or reload our browser, we can commit them on creation to the ARENA Persistence DB by setting `"persist": true`.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/Ball2 -m '{"object_id": "Ball2", "action": "create", "persist": true, "data": {"position": {"x": -1, "y": 1, "z": -1}, "color": "blue", "object_type": "sphere"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/Ball2 -m '{"object_id": "Ball2", "action": "create", "persist": true, "data": {"position": {"x": -1, "y": 1, "z": -1}, "color": "blue", "object_type": "sphere"}}'
 ```
 
 ## Temporary Objects: TTL
@@ -254,7 +254,7 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/Ball2 -m '{"obje
 It's desirable to have objects that don't last forever and pile up. For that there is the 'ttl' parameter that gives objects a lifetime, in seconds. This is an example usage for a sphere that disappears after 5 seconds.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/Ball2 -m '{"object_id": "Ball2", "action": "create", "ttl": 5, "data": {"position": {"x": -1, "y": 1, "z": -1}, "color": "blue", "object_type": "sphere"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/Ball2 -m '{"object_id": "Ball2", "action": "create", "ttl": 5, "data": {"position": {"x": -1, "y": 1, "z": -1}, "color": "blue", "object_type": "sphere"}}'
 ```
 
 ## Transparent Occlusion
@@ -276,7 +276,7 @@ This does not occlude the far background A-Frame layer (like environment compone
 Adds one of many predefined backgrounds ( one of: **none, default, contact, egypt, checkerboard, forest, goaland, yavapai, goldmine, threetowers, poison, arches, tron, japan, dream, volcano, starry, osiris**) to the scene
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/env -m '{"object_id": "env", "action": "update", "type": "object", "data": {"environment": {"preset": "arches"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/env -m '{"object_id": "env", "action": "update", "type": "object", "data": {"environment": {"preset": "arches"}}}'
 ```
 
 ## Physics
@@ -284,15 +284,15 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/env -m '{"object
 You can enable physics (gravity) for a scene object by adding the dynamic-body Component.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/box_3 -m '{"object_id": "box_3", "action": "update", "type": "object", "data": {"dynamic-body": {"type": "dynamic"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/box_3 -m '{"object_id": "box_3", "action": "update", "type": "object", "data": {"dynamic-body": {"type": "dynamic"}}}'
 ```
 
 One physics feature is applying an impulse to an object to set it in motion. This happens in conjunction with an event. As an example, here are messages setting objects fallBox and fallBox2 to respond to `mouseup` and `mousedown` messages with an impulse with a certain force and position.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/fallBox2 '{"object_id": "fallBox2", "action": "create", "data": {"object_type": "cube", "dynamic-body": {"type": "dynamic"}, "impulse": {"on": "mousedown", "force": "1 50 1", "position": "1 1 1"}, "click-listener": "", "position": {"x": 0.1, "y": 4.5, "z": -4}, "scale": {"x": 0.5, "y": 0.5, "z": 0.5}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/fallBox2 '{"object_id": "fallBox2", "action": "create", "data": {"object_type": "cube", "dynamic-body": {"type": "dynamic"}, "impulse": {"on": "mousedown", "force": "1 50 1", "position": "1 1 1"}, "click-listener": "", "position": {"x": 0.1, "y": 4.5, "z": -4}, "scale": {"x": 0.5, "y": 0.5, "z": 0.5}}}'
 
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/fallBox '{"object_id": "fallBox", "action": "create", "data": {"object_type": "cube", "dynamic-body": {"type": "dynamic"}, "impulse": {"on": "mouseup", "force": "1 50 1", "position": "1 1 1"}, "click-listener": "", "position": {"x": 0, "y": 4, "z": -4}, "scale": {"x": 0.5, "y": 0.5, "z": 0.5}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/fallBox '{"object_id": "fallBox", "action": "create", "data": {"object_type": "cube", "dynamic-body": {"type": "dynamic"}, "impulse": {"on": "mouseup", "force": "1 50 1", "position": "1 1 1"}, "click-listener": "", "position": {"x": 0, "y": 4, "z": -4}, "scale": {"x": 0.5, "y": 0.5, "z": 0.5}}}'
 ```
 
 ## Parent/Child Linking
@@ -300,9 +300,9 @@ mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/fallBox '{"objec
 There is support to attach a child to an already-existing parent scene objects. When creating a child object, set the `"parent": "parent_object_id"` value in the JSON data. For example if parent object is gltf-model_Earth and child object is gltf-model_Moon, the commands would look like:
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/gltf-model_Earth -m '{"object_id": "gltf-model_Earth", "action": "create", "data": {"object_type": "gltf-model", "position": {"x": 0, "y": 0.1, "z": 0}, "url": "models/Earth.glb", "scale": {"x": 5, "y": 5, "z": 5}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/gltf-model_Earth -m '{"object_id": "gltf-model_Earth", "action": "create", "data": {"object_type": "gltf-model", "position": {"x": 0, "y": 0.1, "z": 0}, "url": "models/Earth.glb", "scale": {"x": 5, "y": 5, "z": 5}}}'
 
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/gltf-model_Moon -m '{"object_id": "gltf-model_Moon", "action": "create", "data": {"parent": "gltf-model_Earth", "object_type": "gltf-model", "position": {"x": 0, "y": 0.05, "z": 0.6}, "scale": {"x": 0.05, "y": 0.05, "z": 0.05}, "url": "models/Moon.glb" }}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/gltf-model_Moon -m '{"object_id": "gltf-model_Moon", "action": "create", "data": {"parent": "gltf-model_Earth", "object_type": "gltf-model", "position": {"x": 0, "y": 0.05, "z": 0.6}, "scale": {"x": 0.05, "y": 0.05, "z": 0.05}, "url": "models/Moon.glb" }}'
 ```
 
 Child objects inherit attributes of their parent, for example scale. Scale the parent, the child scales with it. If the parent is already scaled, the child scale will be reflected right away. Child position values are relative to the parent and also scaled.
@@ -312,7 +312,7 @@ Child objects inherit attributes of their parent, for example scale. Scale the p
 Navigates to entirely new page into browser when clicked, or other event (requires `click-listener`).
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/cube_1 -m '{"object_id" "cube_1", "action": "create", "type": "object", "data": {"object_type": "cube", "position": {"x": 1, "y": 1, "z": -1}, "click-listener": "", "goto-url": { "dest": "newtab", "on": "mousedown", "url": "http: www.eet.com"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/cube_1 -m '{"object_id" "cube_1", "action": "create", "type": "object", "data": {"object_type": "cube", "position": {"x": 1, "y": 1, "z": -1}, "click-listener": "", "goto-url": { "dest": "newtab", "on": "mousedown", "url": "http: www.eet.com"}}}'
 ```
 
 ## Particles
@@ -322,11 +322,11 @@ Particles are based on [aframe-spe-particles-component](https://github.com/harly
 For now, it's not directly supported, but rather by passing JSON inside the `data{}` element. The syntax for parameter names has been updated so instead of a name like this that is `space-separated` it becomes `spaceSeparated` (camel case). Three examples here have been created starting with the examples in [aframe-spe-particles-component examples](https://harlyq.github.io/aframe-spe-particles-component/) then reformulating to ARENA JSON syntax.
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/smoke -m '{"object_id": "smoke", "action": "create", "data": {"object_type": "cube", "position": {"x": 0, "y": 1, "z": -3.9}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 0.01, "y": 0.01, "z": 0.01}, "color": "#ffffff", "spe-particles": {"texture": "textures/fog.png", "velocity": "1 30 0", "velocitySpread": "2 1 0.2", "particleCount": 50, "maxAge": 4, "size": "3, 8", "opacity": "0, 1, 0", "color": "#aaa, #222"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/smoke -m '{"object_id": "smoke", "action": "create", "data": {"object_type": "cube", "position": {"x": 0, "y": 1, "z": -3.9}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 0.01, "y": 0.01, "z": 0.01}, "color": "#ffffff", "spe-particles": {"texture": "textures/fog.png", "velocity": "1 30 0", "velocitySpread": "2 1 0.2", "particleCount": 50, "maxAge": 4, "size": "3, 8", "opacity": "0, 1, 0", "color": "#aaa, #222"}}}'
 
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/flames -m '{"object_id": "flames", "action": "create", "data": {"object_type": "cube", "position": {"x": 0, "y": 1, "z": -3.8}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 0.01, "y": 0.01, "z": 0.01}, "color": "#ffffff", "spe-particles": {"texture": "textures/explosion_sheet.png", "textureFrames": "5 5", "velocity": "4 100 0", "acceleration": "0 10 0", "accelerationSpread": "0 10 0", "velocitySpread": "4 0 4", "particleCount": 15, "maxAge": 1, "size": "4, 8", "sizeSpread": 2, "opacity": "1, 0", "wiggle": "0 1 0", "blending": "additive"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/flames -m '{"object_id": "flames", "action": "create", "data": {"object_type": "cube", "position": {"x": 0, "y": 1, "z": -3.8}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 0.01, "y": 0.01, "z": 0.01}, "color": "#ffffff", "spe-particles": {"texture": "textures/explosion_sheet.png", "textureFrames": "5 5", "velocity": "4 100 0", "acceleration": "0 10 0", "accelerationSpread": "0 10 0", "velocitySpread": "4 0 4", "particleCount": 15, "maxAge": 1, "size": "4, 8", "sizeSpread": 2, "opacity": "1, 0", "wiggle": "0 1 0", "blending": "additive"}}}'
 
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/sparks -m '{"object_id": "sparks", "action": "create", "data": {"object_type": "cube", "position": {"x": 0, "y": 1, "z": -4}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 0.01, "y": 0.01, "z": 0.01}, "color": "#ffffff", "spe-particles": {"texture": "textures/square.png", "color": "yellow, red", "particleCount": 3, "maxAge": 0.5, "maxAgeSpread": 1, "velocity": "40 200 40", "velocitySpread": "10 3 10", "wiggle": "50 0 50", "wiggleSpread": "15 0 15", "emitterScale": 8, "sizeSpread": 10, "randomizeVelocity": true}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/sparks -m '{"object_id": "sparks", "action": "create", "data": {"object_type": "cube", "position": {"x": 0, "y": 1, "z": -4}, "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}, "scale": {"x": 0.01, "y": 0.01, "z": 0.01}, "color": "#ffffff", "spe-particles": {"texture": "textures/square.png", "color": "yellow, red", "particleCount": 3, "maxAge": 0.5, "maxAgeSpread": 1, "velocity": "40 200 40", "velocitySpread": "10 3 10", "wiggle": "50 0 50", "wiggleSpread": "15 0 15", "emitterScale": 8, "sizeSpread": 10, "randomizeVelocity": true}}}'
 ```
 
 Particles are very complicated and take a lot of parameters. It would not make sense to translate all of them into explicit ARENA types, thus this flexible 'raw JSON' format is used.
@@ -344,7 +344,7 @@ Click events are generated as part of the laser-controls A-Frame entity; you get
 The MQTT topic name for viewing these events can be the standard prefix (e.g. realm/s/public/example/) concatenated with a string made up of object ID that generated the event. An example event MQTT:
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example/fallBox2 '{"object_id": "fallBox2", "action": "clientEvent", "type": "mousedown", "data": {"position": {"x": -0.993, "y": 0.342, "z": -1.797}, "source": "camera_8715_er"}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example/fallBox2 '{"object_id": "fallBox2", "action": "clientEvent", "type": "mousedown", "data": {"position": {"x": -0.993, "y": 0.342, "z": -1.797}, "source": "camera_8715_er"}}'
 ```
 
 {% include alert type="note" title="Note" content="
@@ -368,17 +368,17 @@ Full list of Vive controller event names:
 Some settings are available by setting attributes of the Scene element (see [A-Frame Scene](https://aframe.io/docs/0.9.0/core/scene.html)) for example, turn on statistics:
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example -m '{"object_id": "scene", "action": "update", "type": "object", "data": {"stats": true}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example -m '{"object_id": "scene", "action": "update", "type": "object", "data": {"stats": true}}'
 ```
 
 Customize the fog (notice 3 character hexadecimal color representation):
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example -m '{"object_id": "scene", "action": "update", "type": "object", "data": {"fog": {"type": "linear", "color": "#F00"}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example -m '{"object_id": "scene", "action": "update", "type": "object", "data": {"fog": {"type": "linear", "color": "#F00"}}}'
 ```
 
 Remove the "enter VR" icon:
 
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/public/example -m '{"object_id": "scene", "action": "update", "type": "object", "data": {"vr-mode-ui": {"enabled": false}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/public/example -m '{"object_id": "scene", "action": "update", "type": "object", "data": {"vr-mode-ui": {"enabled": false}}}'
 ```

--- a/content/messaging/index.md
+++ b/content/messaging/index.md
@@ -23,25 +23,25 @@ MQTT messages that define the scene:
 
 ### Create models
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/gltf-model_Earth -m '{"object_id": "gltf-model_Earth", "action": "create", "data": {"object_type": "gltf-model", "position": {"x":0, "y": 0.1, "z": 0}, "url": "models/Earth.glb", "scale": {"x": 5, "y": 5, "z": 5}}}'
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/gltf-model_Moon -m '{"object_id": "gltf-model_Moon", "action": "create", "data": {"parent": "gltf-model_Earth", "object_type": "gltf-model", "position": {"x":0, "y": 0.05, "z": 0.6}, "scale": {"x":0.05, "y": 0.05, "z": 0.05}, "url": "models/Moon.glb" }}'
+mosquitto_pub -h arenaxr.org -t realm/s/example/gltf-model_Earth -m '{"object_id": "gltf-model_Earth", "action": "create", "data": {"object_type": "gltf-model", "position": {"x":0, "y": 0.1, "z": 0}, "url": "models/Earth.glb", "scale": {"x": 5, "y": 5, "z": 5}}}'
+mosquitto_pub -h arenaxr.org -t realm/s/example/gltf-model_Moon -m '{"object_id": "gltf-model_Moon", "action": "create", "data": {"parent": "gltf-model_Earth", "object_type": "gltf-model", "position": {"x":0, "y": 0.05, "z": 0.6}, "scale": {"x":0.05, "y": 0.05, "z": 0.05}, "url": "models/Moon.glb" }}'
 ```
 ### Define animation and movement
  ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/gltf-model_Earth -m '{"object_id" : "gltf-model_Earth", "action": "update", "type": "object", "data": {"animation": { "property": "rotation", "to": "0 360 0", "loop": true, "dur": 20000, "easing": "linear"}} }'
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/gltf-model_Earth -m '{"object_id" : "gltf-model_Earth", "action": "update", "type": "object", "data": {"startEvents": "click", "property": "scale", "dur": 1000, "from": "10 10 10", "to": "5 5 5", "easing": "easeInOutCirc", "loop": 5, "dir": "alternate"} }'
+mosquitto_pub -h arenaxr.org -t realm/s/example/gltf-model_Earth -m '{"object_id" : "gltf-model_Earth", "action": "update", "type": "object", "data": {"animation": { "property": "rotation", "to": "0 360 0", "loop": true, "dur": 20000, "easing": "linear"}} }'
+mosquitto_pub -h arenaxr.org -t realm/s/example/gltf-model_Earth -m '{"object_id" : "gltf-model_Earth", "action": "update", "type": "object", "data": {"startEvents": "click", "property": "scale", "dur": 1000, "from": "10 10 10", "to": "5 5 5", "easing": "easeInOutCirc", "loop": 5, "dir": "alternate"} }'
 ```
 ### Add a click-listener
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/gltf-model_Earth -m '{"object_id" : "gltf-model_Earth", "action": "update", "type": "object", "data": {"click-listener": ""}}'
+mosquitto_pub -h arenaxr.org -t realm/s/example/gltf-model_Earth -m '{"object_id" : "gltf-model_Earth", "action": "update", "type": "object", "data": {"click-listener": ""}}'
 ```
 ### Create marker objects
 ```json
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/box0 -m '{"object_id" : "box0", "action": "create", "data": {"color": "blue", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": 0, "y": 0, "z": 0} }}'
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/box1 -m '{"object_id" : "box1", "action": "create", "data": {"color": "red", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": -0.7, "y": 1.67, "z": 2.11} }}'
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/box2 -m '{"object_id" : "box2", "action": "create", "data": {"color": "red", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": -2.88, "y": 2.80, "z": -2.12} }}'
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/box3 -m '{"object_id" : "box3", "action": "create", "data": {"color": "red", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": -0.09, "y": 1.30, "z": -3.66} }}'
-mosquitto_pub -h arena.andrew.cmu.edu -t realm/s/example/box4 -m '{"object_id" : "box4", "action": "create", "data": {"color": "red", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": 3.31, "y": 2.00, "z": -0.97} }}'
+mosquitto_pub -h arenaxr.org -t realm/s/example/box0 -m '{"object_id" : "box0", "action": "create", "data": {"color": "blue", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": 0, "y": 0, "z": 0} }}'
+mosquitto_pub -h arenaxr.org -t realm/s/example/box1 -m '{"object_id" : "box1", "action": "create", "data": {"color": "red", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": -0.7, "y": 1.67, "z": 2.11} }}'
+mosquitto_pub -h arenaxr.org -t realm/s/example/box2 -m '{"object_id" : "box2", "action": "create", "data": {"color": "red", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": -2.88, "y": 2.80, "z": -2.12} }}'
+mosquitto_pub -h arenaxr.org -t realm/s/example/box3 -m '{"object_id" : "box3", "action": "create", "data": {"color": "red", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": -0.09, "y": 1.30, "z": -3.66} }}'
+mosquitto_pub -h arenaxr.org -t realm/s/example/box4 -m '{"object_id" : "box4", "action": "create", "data": {"color": "red", "object_type": "cube", "scale":  {"x": 0.2, "y": 0.2, "z": 0.2}, "position": {"x": 3.31, "y": 2.00, "z": -0.97} }}'
 ```
 ### Results
 {% include alert type="warning" title="TODO" content="Include awesome demo result from design doc." %}

--- a/content/overview/build.md
+++ b/content/overview/build.md
@@ -15,7 +15,7 @@ We will now do a quick tour of a simple interface to edit ARENA scenes. We will 
 
 ## Add a Scene
 
-Head to the [build page (in a new tab)](https://arena.andrew.cmu.edu/build){:target="\_blank"}. If you never created a scene, it will look similar to this:
+Head to the [build page (in a new tab)](https://arenaxr.org/build){:target="\_blank"}. If you never created a scene, it will look similar to this:
 
 ![](/assets/img/overview/build/build-empty.png)
 
@@ -154,7 +154,7 @@ Landmarks allow to jump to certain places on interest in a scene. If you copied 
 
 <img src="/assets/img/overview/build/landmark-list.png" width="300"/>
 
-This landmark does not make much sense in this scene. After all, [Blumbach](https://3d.si.edu/object/3d/mammuthus-primigenius-blumbach:341c96cd-f967-4540-8ed1-d3fc56d31f12) does not like screen sharing! Let us delete the landmark object. Go back to the [build page (new tab)](https://arena.andrew.cmu.edu/build){:target="\_blank"} and find the `landmarks` object in the object list. Click on the object name to select it (the line will become dark gray):
+This landmark does not make much sense in this scene. After all, [Blumbach](https://3d.si.edu/object/3d/mammuthus-primigenius-blumbach:341c96cd-f967-4540-8ed1-d3fc56d31f12) does not like screen sharing! Let us delete the landmark object. Go back to the [build page (new tab)](https://arenaxr.org/build){:target="\_blank"} and find the `landmarks` object in the object list. Click on the object name to select it (the line will become dark gray):
 
 <img src="/assets/img/overview/build/object-list-landmarks-selected.png" width="500"/>
 

--- a/content/overview/dev-guide.md
+++ b/content/overview/dev-guide.md
@@ -41,7 +41,7 @@ Copy the python script below, and paste it into a ```box.py``` file. After savin
 ```python
 from arena import *
 
-# this creates an object for scenen 'example' at the given arena host and realm
+# this creates an object for scene 'example' at the given arena host
 scene = Scene(host="arenaxr.org", scene="example")
 
 # define a task that will add a box to the scene
@@ -83,7 +83,7 @@ Once you run the script above, you can go back to the scene <b>example</b> in yo
 ![](../../../assets/img/overview/devguide/two-boxes.png)
 
 ## Running from the Command Line
-The target of which server, user and scene are set by the `Scene(host="...",scene="...",namespace="...",debug=False)` function call.  It is also possible to override these using shell environmental variables at the command line as shown below.  This allows a simple way to retarget applications for your own environment without having to change the parameters manually in the code.
+The target of which server, user and scene are set by the `Scene(host="...",scene="...",namespace="...",debug=False)` function call.  It is also possible to override these using shell environmental variables at the command line as shown below.  This allows a simple way to re-target applications for your own environment without having to change the parameters manually in the code.
 ```shell
 export MQTTH=arenaxr.org
 export REALM=realm

--- a/content/overview/dev-guide.md
+++ b/content/overview/dev-guide.md
@@ -33,7 +33,7 @@ Use the **Search ARENA Documentation** bar at the very top of every page on this
 Now, let us create a very simple Python program in the scene <b>example</b>, under the [username you defined the first time you entered the arena](/content/overview/user-guide.html#arena-username). Start by opening the scene in your browser and notice it is empty, with default environment settings.
 
 {% include alert type="note" content="
-Open the <b>example</b> scene under your arena username by entering the following URL in your browser: ```http://arena.andrew.cmu.edu/<your-username>/example```
+Open the <b>example</b> scene under your arena username by entering the following URL in your browser: ```http://arenaxr.org/<your-username>/example```
 "%}
 
 Copy the python script below, and paste it into a ```box.py``` file. After saving the file, execute the script (e.g. ```python3 box.py```; make sure you installed the [python library](/content/python/) first).
@@ -42,7 +42,7 @@ Copy the python script below, and paste it into a ```box.py``` file. After savin
 from arena import *
 
 # this creates an object for scenen 'example' at the given arena host and realm
-scene = Scene(host="arena.andrew.cmu.edu", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 # define a task that will add a box to the scene
 @scene.run_once
@@ -64,7 +64,7 @@ Now, go back to your browser and <b>refresh</b> the page. You will notice that t
 ```python
 from arena import *
 
-scene = Scene(host="arena.andrew.cmu.edu", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_box():
@@ -83,7 +83,7 @@ Once you run the script above, you can go back to the scene <b>example</b> in yo
 ![](../../../assets/img/overview/devguide/two-boxes.png)
 
 ## Running from the Command Line
-The target of which server, user and scene are set by the `Scene(host="...",realm="...",scene="...",namespace="...",debug=False)` function call.  It is also possible to override these using shell environmental variables at the command line as shown below.  This allows a simple way to retarget applications for your own environment without having to change the parameters manually in the code.
+The target of which server, user and scene are set by the `Scene(host="...",scene="...",namespace="...",debug=False)` function call.  It is also possible to override these using shell environmental variables at the command line as shown below.  This allows a simple way to retarget applications for your own environment without having to change the parameters manually in the code.
 ```shell
 export MQTTH=arenaxr.org
 export REALM=realm
@@ -143,7 +143,7 @@ A more advanced manipulation of objects in the ARENA is using 3d models as [GLTF
 ```python
 from arena import *
 
-scene = Scene(host="arena.andrew.cmu.edu", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 obj = GLTF(object_id="duck_1",
             position=(-1, 1, -3),

--- a/content/overview/user-guide.md
+++ b/content/overview/user-guide.md
@@ -19,7 +19,7 @@ For the best ARENA performance, you need a couple of things:
 
 ## Opening a Scene
 
-Let us have a look at the **lobby** scene: [https://arena.andrew.cmu.edu/public/lobby](https://arena.andrew.cmu.edu/public/lobby){:target="\_blank"}.
+Let us have a look at the **lobby** scene: [https://arenaxr.org/public/lobby](https://arenaxr.org/public/lobby){:target="\_blank"}.
 
 The link above will open in a new tab. Since ARENA is a collaborative, multi-user environment, you may see other people there. Say Hi!
 
@@ -43,7 +43,7 @@ If you choose to login using your Google account, you will be asked to signup an
 
 <img src="/assets/img/overview/signup.png" width="500"/>
 
-This will create a namespace under which you can have your own scenes. For example, ```user1```, will have his scenes under ```http://arena.andrew.cmu.edu/user1/```.
+This will create a namespace under which you can have your own scenes. For example, ```user1```, will have his scenes under ```http://arenaxr.org/user1/```.
 
 ## Permissions
 

--- a/content/python/index.md
+++ b/content/python/index.md
@@ -46,7 +46,7 @@ That forms a layer, in turn, on top of [A-Frame](https://aframe.io/) and [THREE.
 Examples of ARENA-py programs can be found [here](https://github.com/conix-center/ARENA-py/tree/master/examples) and [here](https://github.com/conix-center/ARENA-py/tree/master/system-tests).
 
 ## Running from the Command Line
-The target of which server, user and scene are set by the `Scene(host="...",scene="...",namespace="...",debug=False)` function call.  It is also possible to override these using environmental variables at the command line as shown below.  This allows a simple way to retarget applications for your own environment without having to change the parameters manually in the code.
+The target of which server, user and scene are set by the `Scene(host="...",scene="...",namespace="...",debug=False)` function call.  It is also possible to override these using environmental variables at the command line as shown below.  This allows a simple way to re-target applications for your own environment without having to change the parameters manually in the code.
 ```shell
 export MQTTH=arenaxr.org
 export REALM=realm

--- a/content/python/index.md
+++ b/content/python/index.md
@@ -28,7 +28,7 @@ python hello.py
 ```python
 from arena import *
 
-scene = Scene(host="arena.andrew.cmu.edu", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_box():
@@ -46,7 +46,7 @@ That forms a layer, in turn, on top of [A-Frame](https://aframe.io/) and [THREE.
 Examples of ARENA-py programs can be found [here](https://github.com/conix-center/ARENA-py/tree/master/examples) and [here](https://github.com/conix-center/ARENA-py/tree/master/system-tests).
 
 ## Running from the Command Line
-The target of which server, user and scene are set by the `Scene(host="...",realm="...",scene="...",namespace="...",debug=False)` function call.  It is also possible to override these using environmental variables at the command line as shown below.  This allows a simple way to retarget applications for your own environment without having to change the parameters manually in the code.
+The target of which server, user and scene are set by the `Scene(host="...",scene="...",namespace="...",debug=False)` function call.  It is also possible to override these using environmental variables at the command line as shown below.  This allows a simple way to retarget applications for your own environment without having to change the parameters manually in the code.
 ```shell
 export MQTTH=arenaxr.org
 export REALM=realm
@@ -61,7 +61,7 @@ Connected!
 =====
 ...
 ```
-If not specified the namespace is your current logged in user-id. The most common use-case is to simply update `SCENE` and `MQTTH`. 
+If not specified the namespace is your current logged in user-id. The most common use-case is to simply update `SCENE` and `MQTTH`.
 
 
 ## Authentication

--- a/content/python/scenes.md
+++ b/content/python/scenes.md
@@ -12,8 +12,8 @@ Scenes give ARENA-py programs access to an ARENA scene. It provides an interface
 ## Scene Access
 To get access to a scene in the ARENA, create a `Scene` object. Make sure you have proper permissions to access it!
 ```python
-scene = Scene(host="arena.andrew.cmu.edu", realm="realm", scene="example")
-# scene = Arena(host="arena.andrew.cmu.edu", realm="realm", scene="example") works too
+scene = Scene(host="arenaxr.org", scene="example")
+# scene = Arena(host="arenaxr.org", scene="example") works too
 ```
 
 ## Arguments

--- a/content/tools/authoring.md
+++ b/content/tools/authoring.md
@@ -15,7 +15,7 @@ An AR/VR capable editing tool to create/manipulate/delete ARENA objects. See top
     ```shell
     python3 tools/arb/arb.py hello
     ```
-1. Interact with the tool at https://arena.andrew.cmu.edu/[your username]/hello
+1. Interact with the tool at https://arenaxr.org/[your username]/hello
 
 ## Demo Video
 <figure class="video_container">

--- a/content/tools/filestore.md
+++ b/content/tools/filestore.md
@@ -9,7 +9,7 @@ parent: Tools
 
 {% include alert type="warning" title="Coming Soon" content="Writing in progress..." %}
 
-To add models or programs to the ARENA, they will have to be stored somewhere. The [file store](https://arena.andrew.cmu.edu/storemng/) is where most of these files are currently located, and can easily be accessed.
+To add models or programs to the ARENA, they will have to be stored somewhere. The [file store](https://arenaxr.org/storemng/) is where most of these files are currently located, and can easily be accessed.
 
 ![](../../assets/img/overview/filestore/fs1.png)
 

--- a/content/tools/index.md
+++ b/content/tools/index.md
@@ -15,7 +15,7 @@ has_children: true
 
 ## Monitor network connections
 
-Take a minute to view the ARENA network's connections as you move around in the ARENA on our [Network graph](https://arena.andrew.cmu.edu/network). Clients connected <span style="background-color: black; color: orange;">(orange square)</span>, client subnets <span style="background-color: black; color: gray;">(gray box)</span>, MQTT topics <span style="background-color: black; color: DeepSkyBlue;">(blue circle)</span>, and their current relationships and throughput <span style="background-color: black; color: white;">(white arrow)</span> can be visualized.
+Take a minute to view the ARENA network's connections as you move around in the ARENA on our [Network graph](https://arenaxr.org/network). Clients connected <span style="background-color: black; color: orange;">(orange square)</span>, client subnets <span style="background-color: black; color: gray;">(gray box)</span>, MQTT topics <span style="background-color: black; color: DeepSkyBlue;">(blue circle)</span>, and their current relationships and throughput <span style="background-color: black; color: white;">(white arrow)</span> can be visualized.
 
 Controls:
 

--- a/content/tools/params.md
+++ b/content/tools/params.md
@@ -8,7 +8,7 @@ parent: Tools
 ## URL Parameters
 
 For advanced users, the ARENA accepts URL parameters to override some internal defaults. These are passed in the address bar, after the scene name, e.g.:
-```https://arena.andrew.cmu.edu/public/scenename/?name=MyName&scene=AScene```
+```https://arenaxr.org/public/scenename/?name=MyName&scene=AScene```
 
 The following URL parameters are accepted.
 
@@ -21,7 +21,7 @@ The following URL parameters are accepted.
 | fixedCamera (string)         | Sets the camera name to the given value **and** enables VIO output to ```realm/vio/scene-name/camera-name``` ; ```fixedCamera=iPhone``` will set the camera name **exactly** to the given value (not add any prefix/suffix)|
 | lat (float)                  | Override device location; (e.g. ```lat=40.4427```)                                                                                                                                |
 | long (float)                 | Override device location; (e.g. ```long=79.9430```)                                                                                                                               |
-| mqttHost (string)            | Override MQTT host address (e.g. ```mqttHost=arena.andrew.cmu.edu```)                                                                                                             |
+| mqttHost (string)            | Override MQTT host address (e.g. ```mqttHost=arenaxr.org```)                                                                                                             |
 | name (string)                | Set user name (e.g. ```name=MyName```)                                                                                                                                            |
 | networkedTagSolver (bool)    | *AprilTag location solver parameter*. When true, publishes tag detections (to ```realm/g/a/camera-name```) **and defers all tag solving of client camera to a solver sitting on pubsub**|
 | publishDetections (bool)     | *AprilTag location solver parameter*. Ignored if ```networkedTagSolver=true```. When true, publishes tag detections (to ```realm/g/a/camera-name```); **still processes the tag and relocalizes accordingly**|

--- a/content/troubleshooting.md
+++ b/content/troubleshooting.md
@@ -19,7 +19,7 @@ Here are some common situations which can help when programming and collaboratin
 ## Where is my Object?
 - Is the object's position below the ground? The "y" position will negative below the default visible floor.
 - Is the object's scale too big/small? Models especially have wild differences in scale, try increasing/decreasing the order of magnitude of the scale. Try scale of 10, 1, 0.1, or 0.01.
-- Does the scene name in the URL match the scene name/topic where the object was created? e.g. URL is `https://arena.andrew.cmu.edu/[your username]/example` and MQTT topic published to is `realm/s/[your username]/example/some_object_1`.
+- Does the scene name in the URL match the scene name/topic where the object was created? e.g. URL is `https://arenaxr.org/[your username]/example` and MQTT topic published to is `realm/s/[your username]/example/some_object_1`.
 - Does the object appear in the left column of the [A-Frame Scene Inspector](https://aframe.io/docs/1.0.0/introduction/visual-inspector-and-dev-tools.html)?
 
 ## I have different problem, where can I get help?


### PR DESCRIPTION
- Remove param realm in examples to use default and avoid user confusion.
- Set all urls to use `arena.org`.
- Added shortened webxr polyfill url.
- Also closes https://github.com/conix-center/ARENA-py/issues/92.